### PR TITLE
Limit recent activities to 5

### DIFF
--- a/includes/class-strava-stories-rest.php
+++ b/includes/class-strava-stories-rest.php
@@ -63,7 +63,7 @@ class Strava_Stories_Rest {
 			return new WP_REST_Response( array( 'ok' => false, 'error' => 'not_connected' ), 403 );
 		}
 
-		$activities = $client->get_recent_activities( $user_id, 10 );
+		$activities = $client->get_recent_activities( $user_id, 5 );
 		if ( is_wp_error( $activities ) ) {
 			return new WP_REST_Response(
 				array( 'ok' => false, 'error' => $activities->get_error_message() ),


### PR DESCRIPTION
## Summary
- Drops the activities widget from 10 to 5 results (`includes/class-strava-stories-rest.php:66`).
- With 5 results, the existing `backfill_budget = 5` now covers every activity, so we never silently fall back to the styled card for missing `embed_token`s — and the worst-case API cost is halved (1 listing + up to 5 details vs. 1 + up to 10).

Fixes #2

## Test plan
- [ ] Connect Strava, load the dashboard widget, verify exactly 5 activities are returned.
- [ ] Confirm pager shows `1 of 5` max and prev/next behave correctly.
- [ ] Spot-check that activities without `embed_token` from the listing now get backfilled (no styled-card fallback for the visible 5).