### PR TITLE
Add Connect button feedback on the settings screen

### DIFF
--- a/assets/strava-stories-connect-ux.js
+++ b/assets/strava-stories-connect-ux.js
@@ -1,0 +1,60 @@
+/**
+ * Strava Stories — Connect button feedback.
+ *
+ * Strava's OAuth dance can complete in well under a second when the
+ * provider auto-approves a previously authorized app. The resulting
+ * visual change can be so brief that it looks like nothing happened.
+ * This script gives the Connect button an immediate "Connecting…"
+ * state, and on return surfaces a brief highlight on the row.
+ */
+( function () {
+	'use strict';
+
+	function markConnecting( link ) {
+		if ( link.dataset.stravaStoriesConnecting === '1' ) {
+			return;
+		}
+		link.dataset.stravaStoriesConnecting = '1';
+		link.setAttribute( 'aria-busy', 'true' );
+		link.style.pointerEvents = 'none';
+		link.style.opacity = '0.7';
+		link.textContent = link.dataset.connectingLabel || 'Connecting…';
+	}
+
+	function bindConnectButtons() {
+		var links = document.querySelectorAll(
+			'a.button[href*="strava_stories_connect="]'
+		);
+		Array.prototype.forEach.call( links, function ( link ) {
+			link.addEventListener( 'click', function () {
+				markConnecting( link );
+			} );
+		} );
+	}
+
+	function flashConnectedRow() {
+		var url = new URL( window.location.href );
+		if ( ! url.searchParams.get( 'connected' ) ) {
+			return;
+		}
+		var row = document.querySelector( 'tr[data-strava-stories-row]' );
+		if ( ! row ) {
+			return;
+		}
+		row.classList.add( 'strava-stories-row-just-connected' );
+		row.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+		window.setTimeout( function () {
+			row.classList.remove( 'strava-stories-row-just-connected' );
+		}, 2400 );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', function () {
+			bindConnectButtons();
+			flashConnectedRow();
+		} );
+	} else {
+		bindConnectButtons();
+		flashConnectedRow();
+	}
+} )();

--- a/assets/strava-stories.css
+++ b/assets/strava-stories.css
@@ -290,3 +290,30 @@
 	background: #f0f0f1;
 	color: #50575e;
 }
+
+/* Connect button feedback */
+@keyframes strava-stories-row-flash {
+	0%   { background-color: #ffeede; }
+	100% { background-color: transparent; }
+}
+
+.strava-stories-row-just-connected td {
+	animation: strava-stories-row-flash 2.4s ease-out;
+}
+
+a.button[data-strava-stories-connecting="1"]::after {
+	content: "";
+	display: inline-block;
+	margin-left: 8px;
+	width: 12px;
+	height: 12px;
+	border: 2px solid currentColor;
+	border-top-color: transparent;
+	border-radius: 50%;
+	animation: strava-stories-spin 0.8s linear infinite;
+	vertical-align: -2px;
+}
+
+@keyframes strava-stories-spin {
+	to { transform: rotate(360deg); }
+}

--- a/includes/class-strava-stories-admin.php
+++ b/includes/class-strava-stories-admin.php
@@ -111,7 +111,7 @@ class Strava_Stories_Admin {
 
 			<table class="widefat striped" style="max-width:720px;">
 				<tbody>
-					<tr>
+					<tr data-strava-stories-row="connection">
 						<td><strong><?php esc_html_e( 'Status', 'strava-stories' ); ?></strong></td>
 						<td>
 							<?php if ( ! empty( $status['connected'] ) ) : ?>
@@ -142,6 +142,7 @@ class Strava_Stories_Admin {
 							<?php else : ?>
 								<a class="button button-primary"
 									href="<?php echo esc_url( $connect_url ); ?>"
+									data-connecting-label="<?php esc_attr_e( 'Connecting…', 'strava-stories' ); ?>"
 									<?php if ( ! $configured ) echo 'aria-disabled="true" style="pointer-events:none;opacity:.5"'; ?>
 								>
 									<?php esc_html_e( 'Connect Strava', 'strava-stories' ); ?>

--- a/strava-stories.php
+++ b/strava-stories.php
@@ -114,4 +114,14 @@ function strava_stories_enqueue_assets( string $hook ): void {
 			true
 		);
 	}
+
+	if ( $is_settings ) {
+		wp_enqueue_script(
+			'strava-stories-connect-ux',
+			STRAVA_STORIES_URL . 'assets/strava-stories-connect-ux.js',
+			array(),
+			STRAVA_STORIES_VERSION,
+			true
+		);
+	}
 }


### PR DESCRIPTION
## Summary

When Strava auto-approves a previously authorized app, the full connect → authorize → callback → redirect chain can complete in under a second. The settings page rerenders, but the visible state can change so briefly that it looks like the click did nothing — only a manual refresh makes the new "Connected" state register for the user.

This PR adds two small UX affordances on the settings screen:

- **Immediate "Connecting…" spinner** on the Connect button the moment it's clicked, so feedback fires before the redirect chain starts.
- **Row highlight + scroll into view** when the page renders with \`?connected=1\`, so success is unmistakable when the redirect chain lands back on the settings page.

The OAuth flow itself is unchanged — this is purely client-side polish.

## Implementation

- New \`assets/strava-stories-connect-ux.js\`, enqueued only on the Strava Stories settings screen.
- A small block of CSS appended to the existing \`assets/strava-stories.css\` for the row flash + spinner.
- Connection \`<tr>\` carries \`data-strava-stories-row="connection"\` so the success flash targets the right row.
- Connect anchor carries a translatable \`data-connecting-label\` so the spinner text localizes.

## Test plan

- [ ] Connect Strava for the first time → consent screen appears → return → row flashes briefly with "Connected as …".
- [ ] Disconnect, then connect again (Strava auto-approves) → button shows "Connecting…" with spinner immediately, then row flashes on return.
- [ ] Click "Connect Strava" before the OAuth app is configured (button is disabled) → no spinner, no nav.
- [ ] No regressions on the existing notices or the credentials form.