### PR TITLE
Keep trashed drafts in the widget exclusion list

### DIFF
--- a/includes/class-strava-stories-rest.php
+++ b/includes/class-strava-stories-rest.php
@@ -277,8 +277,15 @@ class Strava_Stories_Rest {
 	/**
 	 * Map of Strava activity IDs that already have an associated post.
 	 *
-	 * Once a post (draft or published) exists for an activity, the widget
-	 * shouldn't offer it again — the author already started a story for it.
+	 * Once a post exists for an activity — draft, published, *or trashed* —
+	 * the widget shouldn't offer that activity again. Trashed posts are
+	 * intentionally included: if an author started a story and then trashed
+	 * it, having the activity reappear in the widget is the "folks get
+	 * confused" case from issue #5. To bring an activity back, the author
+	 * permanently deletes the trashed post.
+	 *
+	 * `auto-draft` is excluded because WP can create speculative auto-drafts
+	 * that the author never intended to keep.
 	 *
 	 * @return array<string, true>
 	 */
@@ -289,7 +296,7 @@ class Strava_Stories_Rest {
 			 FROM {$wpdb->postmeta} pm
 			 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
 			 WHERE pm.meta_key = '_strava_stories_activity'
-			   AND p.post_status NOT IN ( 'trash', 'auto-draft' )"
+			   AND p.post_status != 'auto-draft'"
 		);
 		$ids = array();
 		foreach ( (array) $rows as $row ) {


### PR DESCRIPTION
Follow-up to #4 / re-opens the spirit of #5.

## Problem
The widget filter excluded both `trash` and `auto-draft`, so trashing a draft
made its Strava activity reappear in the widget — the exact confusion issue #5
called out. Verified locally: the only post with `_strava_stories_activity`
meta in the test DB was in `trash`, and the activity was back in the widget.

## Fix
Only exclude `auto-draft`. Drafts, published posts, and trashed posts now all
keep the activity hidden. Author can permanently delete the post to bring the
activity back.

## Test plan
- [ ] Create a draft from an activity → activity disappears from widget.
- [ ] Trash the draft → activity stays hidden.
- [ ] Permanently delete the trashed draft → activity reappears.