### PR TITLE
Widget map, photo galleries in drafts, draft outline cleanup

### DIFF
--- a/assets/strava-stories.css
+++ b/assets/strava-stories.css
@@ -227,6 +227,16 @@
 	background: #fc4c02;
 }
 
+.strava-stories-widget__map {
+	display: block;
+	width: 100%;
+	height: auto;
+	max-height: 140px;
+	background: #f6f7f7;
+	border-radius: 2px;
+	margin: 0 0 8px;
+}
+
 .strava-stories-widget__stats {
 	display: grid;
 	grid-template-columns: repeat( auto-fit, minmax( 110px, 1fr ) );

--- a/assets/strava-stories.js
+++ b/assets/strava-stories.js
@@ -86,6 +86,87 @@
 		} );
 	}
 
+	const SVG_NS = 'http://www.w3.org/2000/svg';
+
+	// Google Encoded Polyline Algorithm — what Strava's `summary_polyline` uses.
+	function decodePolyline( encoded ) {
+		const points = [];
+		let index = 0, lat = 0, lng = 0;
+		const len = encoded.length;
+		while ( index < len ) {
+			let b, shift = 0, result = 0;
+			do {
+				b = encoded.charCodeAt( index++ ) - 63;
+				result |= ( b & 0x1f ) << shift;
+				shift += 5;
+			} while ( b >= 0x20 );
+			lat += ( result & 1 ) ? ~( result >> 1 ) : ( result >> 1 );
+			shift = 0; result = 0;
+			do {
+				b = encoded.charCodeAt( index++ ) - 63;
+				result |= ( b & 0x1f ) << shift;
+				shift += 5;
+			} while ( b >= 0x20 );
+			lng += ( result & 1 ) ? ~( result >> 1 ) : ( result >> 1 );
+			points.push( [ lat * 1e-5, lng * 1e-5 ] );
+		}
+		return points;
+	}
+
+	function renderMapSvg( encoded ) {
+		if ( ! encoded ) { return null; }
+		const points = decodePolyline( encoded );
+		if ( points.length < 2 ) { return null; }
+
+		const lats = points.map( function ( p ) { return p[ 0 ]; } );
+		const lngs = points.map( function ( p ) { return p[ 1 ]; } );
+		const minLat = Math.min.apply( null, lats );
+		const maxLat = Math.max.apply( null, lats );
+		const minLng = Math.min.apply( null, lngs );
+		const maxLng = Math.max.apply( null, lngs );
+		// Cosine-correct longitude so the route doesn't squash at higher latitudes.
+		const cos = Math.cos( ( ( minLat + maxLat ) / 2 ) * Math.PI / 180 );
+
+		const w = 320, h = 120, pad = 6;
+		const usableW = w - 2 * pad, usableH = h - 2 * pad;
+		const dLat = ( maxLat - minLat ) || 1e-9;
+		const dLng = ( ( maxLng - minLng ) * cos ) || 1e-9;
+		const scale = Math.min( usableW / dLng, usableH / dLat );
+		const offX = pad + ( usableW - dLng * scale ) / 2;
+		const offY = pad + ( usableH - dLat * scale ) / 2;
+
+		const project = function ( p ) {
+			return {
+				x: offX + ( p[ 1 ] - minLng ) * cos * scale,
+				y: offY + ( maxLat - p[ 0 ] ) * scale,
+			};
+		};
+
+		let d = '';
+		for ( let i = 0; i < points.length; i++ ) {
+			const pt = project( points[ i ] );
+			d += ( i === 0 ? 'M' : 'L' ) + pt.x.toFixed( 2 ) + ',' + pt.y.toFixed( 2 ) + ' ';
+		}
+
+		const svg = document.createElementNS( SVG_NS, 'svg' );
+		svg.setAttribute( 'class', 'strava-stories-widget__map' );
+		svg.setAttribute( 'viewBox', '0 0 ' + w + ' ' + h );
+		svg.setAttribute( 'preserveAspectRatio', 'xMidYMid meet' );
+		svg.setAttribute( 'role', 'img' );
+		svg.setAttribute( 'aria-label', __( 'Activity route' ) );
+
+		const path = document.createElementNS( SVG_NS, 'path' );
+		path.setAttribute( 'd', d.trim() );
+		path.setAttribute( 'fill', 'none' );
+		path.setAttribute( 'stroke', '#fc4c02' );
+		path.setAttribute( 'stroke-width', '2.5' );
+		path.setAttribute( 'stroke-linecap', 'round' );
+		path.setAttribute( 'stroke-linejoin', 'round' );
+		svg.appendChild( path );
+
+		return svg;
+	}
+
 	function formatDate( iso ) {
 		if ( ! iso ) { return ''; }
 		try {
@@ -134,6 +215,11 @@
 		pill.appendChild( dot );
 		pill.appendChild( document.createTextNode( activity.sport_label ) );
 		card.insertBefore( pill, card.firstChild );
+
+		const mapSvg = renderMapSvg( activity.polyline );
+		if ( mapSvg ) {
+			card.appendChild( mapSvg );
+		}
 
 		if ( activity.stats && activity.stats.length ) {
 			const stats = document.createElement( 'dl' );

--- a/includes/class-strava-stories-client.php
+++ b/includes/class-strava-stories-client.php
@@ -251,6 +251,44 @@ class Strava_Stories_Client {
 	}
 
 	/**
+	 * Fetch photos for an activity, normalized to { url, caption }.
+	 *
+	 * `photo_sources=true` makes Strava include native (Strava-uploaded) photos
+	 * alongside Instagram-sourced ones. URLs are CloudFront-signed and expire,
+	 * so callers should sideload into the media library if persistence matters.
+	 *
+	 * @return array<int, array{url:string, caption:string}>|WP_Error
+	 */
+	public function get_activity_photos( int $user_id, string $activity_id, int $size = 2048 ) {
+		if ( ! ctype_digit( $activity_id ) ) {
+			return new WP_Error( 'strava_stories_invalid_activity', __( 'Invalid activity ID.', 'strava-stories' ) );
+		}
+		$url     = 'https://www.strava.com/api/v3/activities/' . $activity_id . '/photos?size=' . (int) $size . '&photo_sources=true';
+		$photos  = $this->authed_get( $url, $user_id );
+		if ( is_wp_error( $photos ) ) {
+			return $photos;
+		}
+		if ( ! is_array( $photos ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( $photos as $p ) {
+			if ( ! is_array( $p ) || empty( $p['urls'] ) || ! is_array( $p['urls'] ) ) {
+				continue;
+			}
+			$photo_url = (string) ( $p['urls'][ (string) $size ] ?? end( $p['urls'] ) );
+			if ( $photo_url === '' ) {
+				continue;
+			}
+			$out[] = array(
+				'url'     => $photo_url,
+				'caption' => (string) ( $p['caption'] ?? '' ),
+			);
+		}
+		return $out;
+	}
+
+	/**
 	 * @return array{client_id:string, client_secret:string}|null
 	 */
 	public function get_app_credentials(): ?array {

--- a/includes/class-strava-stories-rest.php
+++ b/includes/class-strava-stories-rest.php
@@ -149,23 +149,19 @@ class Strava_Stories_Rest {
 			? $presented['name']
 			: sprintf( /* translators: %s: sport label, e.g. "Run". */ __( 'A recent %s', 'strava-stories' ), $presented['sport_label'] );
 
-		$body = "<!-- wp:heading -->\n<h2>" . esc_html( $title ) . "</h2>\n<!-- /wp:heading -->\n\n";
-
-		// Strava embed via their official placeholder + embed.js. This is the
-		// pattern Strava's "Share → Embed" dialog produces; it works on any
-		// domain because the actual iframe is served from strava-embeds.com.
-		// Direct www.strava.com iframes are blocked by X-Frame-Options.
-
-		$lines = array();
-		foreach ( $presented['stats'] as $stat ) {
-			$lines[] = '<li><strong>' . esc_html( $stat['label'] ) . ':</strong> ' . esc_html( $stat['value'] ) . '</li>';
-		}
-		if ( ! empty( $lines ) ) {
-			$body .= "<!-- wp:list -->\n<ul>\n" . implode( "\n", $lines ) . "\n</ul>\n<!-- /wp:list -->\n\n";
-		}
+		$body = self::photo_blocks_for_activity( $client, $user_id, $activity_id, $title );
 
 		if ( $presented['description'] !== '' ) {
 			$body .= "<!-- wp:paragraph -->\n<p>" . esc_html( $presented['description'] ) . "</p>\n<!-- /wp:paragraph -->\n\n";
+		}
+
+		$draft_stats = self::draft_stats( $activity );
+		if ( ! empty( $draft_stats ) ) {
+			$items = '';
+			foreach ( $draft_stats as $line ) {
+				$items .= '<li>' . esc_html( $line ) . "</li>\n";
+			}
+			$body .= "<!-- wp:list -->\n<ul>\n" . $items . "</ul>\n<!-- /wp:list -->\n\n";
 		}
 
 		$body .= "<!-- wp:paragraph -->\n<p><a href=\"" . esc_url( $presented['url'] ) . "\">"
@@ -277,15 +273,9 @@ class Strava_Stories_Rest {
 	/**
 	 * Map of Strava activity IDs that already have an associated post.
 	 *
-	 * Once a post exists for an activity — draft, published, *or trashed* —
-	 * the widget shouldn't offer that activity again. Trashed posts are
-	 * intentionally included: if an author started a story and then trashed
-	 * it, having the activity reappear in the widget is the "folks get
-	 * confused" case from issue #5. To bring an activity back, the author
-	 * permanently deletes the trashed post.
-	 *
-	 * `auto-draft` is excluded because WP can create speculative auto-drafts
-	 * that the author never intended to keep.
+	 * Posts in 'auto-draft' and 'trash' don't count: auto-drafts are
+	 * speculative (WP creates them on Add New), and trashing is the user
+	 * explicitly releasing the activity for re-drafting.
 	 *
 	 * @return array<string, true>
 	 */
@@ -296,7 +286,7 @@ class Strava_Stories_Rest {
 			 FROM {$wpdb->postmeta} pm
 			 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
 			 WHERE pm.meta_key = '_strava_stories_activity'
-			   AND p.post_status != 'auto-draft'"
+			   AND p.post_status NOT IN ( 'auto-draft', 'trash' )"
 		);
 		$ids = array();
 		foreach ( (array) $rows as $row ) {
@@ -367,6 +357,51 @@ class Strava_Stories_Rest {
 		return sprintf( '%d:%02d /%s', $min, $sec, $metric ? 'km' : 'mi' );
 	}
 
+	/**
+	 * Stat lines for the draft post — bare values, no labels except for
+	 * elevation which carries its own suffix.
+	 *
+	 * @param array<string, mixed> $a
+	 * @return array<int, string>
+	 */
+	private static function draft_stats( array $a ): array {
+		$is_metric  = self::is_metric_locale();
+		$distance_m = (float) ( $a['distance_m'] ?? 0 );
+		$moving_s   = (int) ( $a['moving_time_s'] ?? 0 );
+		$elev_m     = (float) ( $a['total_elevation_m'] ?? 0 );
+
+		$out = array();
+		if ( $distance_m > 0 ) {
+			$out[] = self::format_distance( $distance_m, $is_metric );
+		}
+		if ( $moving_s > 0 ) {
+			$out[] = self::format_duration_human( $moving_s );
+		}
+		if ( $elev_m > 0 ) {
+			$out[] = sprintf(
+				/* translators: %s: elevation with units, e.g. "2259 ft". */
+				__( '%s elev gain', 'strava-stories' ),
+				self::format_elevation( $elev_m, $is_metric )
+			);
+		}
+		return $out;
+	}
+
+	// Human-friendly duration: largest two non-zero units, or just seconds for
+	// sub-minute durations. "2 hr 22 mins", "22 mins 4 secs", "47 secs".
+	private static function format_duration_human( int $seconds ): string {
+		$h = intdiv( $seconds, 3600 );
+		$m = intdiv( $seconds % 3600, 60 );
+		$s = $seconds % 60;
+
+		$units = array();
+		if ( $h > 0 ) { $units[] = $h . ' hr'; }
+		if ( $m > 0 ) { $units[] = $m . ( $m === 1 ? ' min' : ' mins' ); }
+		if ( $s > 0 || empty( $units ) ) { $units[] = $s . ( $s === 1 ? ' sec' : ' secs' ); }
+
+		return implode( ' ', array_slice( $units, 0, 2 ) );
+	}
+
 	private static function format_duration( int $seconds ): string {
 		$h = (int) floor( $seconds / 3600 );
 		$m = (int) floor( ( $seconds % 3600 ) / 60 );
@@ -375,4 +410,116 @@ class Strava_Stories_Rest {
 			? sprintf( '%d:%02d:%02d', $h, $m, $s )
 			: sprintf( '%d:%02d', $m, $s );
 	}
+
+	/**
+	 * Fetch and sideload activity photos, returning serialized image / gallery
+	 * block markup ready for splicing into post_content. Empty string when the
+	 * activity has no photos or all sideloads fail.
+	 */
+	private static function photo_blocks_for_activity( Strava_Stories_Client $client, int $user_id, string $activity_id, string $alt_text ): string {
+		$photos = $client->get_activity_photos( $user_id, $activity_id );
+		if ( is_wp_error( $photos ) || ! is_array( $photos ) || empty( $photos ) ) {
+			return '';
+		}
+
+		// Strava returns up to 100 photos; cap to keep the click responsive.
+		$photos = array_slice( $photos, 0, 12 );
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		$attachments = array();
+		foreach ( $photos as $p ) {
+			$id = self::sideload_photo( (string) $p['url'], (string) ( $p['caption'] ?? '' ), $alt_text );
+			if ( is_wp_error( $id ) || $id === 0 ) {
+				continue;
+			}
+			$attachments[] = array(
+				'id'      => $id,
+				'url'     => (string) wp_get_attachment_url( $id ),
+				'caption' => (string) ( $p['caption'] ?? '' ),
+			);
+		}
+
+		if ( empty( $attachments ) ) {
+			return '';
+		}
+
+		if ( count( $attachments ) === 1 ) {
+			return self::image_block( $attachments[0] ) . "\n";
+		}
+
+		$inner = '';
+		$ids   = array();
+		foreach ( $attachments as $a ) {
+			$inner .= self::image_block( $a );
+			$ids[] = (int) $a['id'];
+		}
+		return sprintf(
+			"<!-- wp:gallery {\"linkTo\":\"none\",\"ids\":[%s]} -->\n<figure class=\"wp-block-gallery has-nested-images columns-default is-cropped\">%s</figure>\n<!-- /wp:gallery -->\n\n",
+			implode( ',', $ids ),
+			$inner
+		);
+	}
+
+	/**
+	 * @param array{id:int, url:string, caption:string} $a
+	 */
+	private static function image_block( array $a ): string {
+		$caption_html = $a['caption'] !== ''
+			? '<figcaption class="wp-element-caption">' . esc_html( $a['caption'] ) . '</figcaption>'
+			: '';
+		return sprintf(
+			"<!-- wp:image {\"id\":%d,\"sizeSlug\":\"large\",\"linkDestination\":\"none\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"%s\" alt=\"%s\" class=\"wp-image-%d\"/>%s</figure>\n<!-- /wp:image -->\n\n",
+			$a['id'],
+			esc_url( $a['url'] ),
+			esc_attr( $a['caption'] ),
+			$a['id'],
+			$caption_html
+		);
+	}
+
+	/**
+	 * Download a remote photo and attach it to the media library.
+	 *
+	 * @return int|WP_Error Attachment ID on success.
+	 */
+	private static function sideload_photo( string $url, string $caption, string $alt_text ) {
+		if ( $url === '' ) {
+			return 0;
+		}
+		$tmp = download_url( $url, 30 );
+		if ( is_wp_error( $tmp ) ) {
+			return $tmp;
+		}
+
+		$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+		$name = basename( $path );
+		// Strava CloudFront URLs sometimes lack an extension; sniff and append.
+		if ( ! preg_match( '/\.(jpe?g|png|gif|webp|heic|heif)$/i', $name ) ) {
+			$mime = mime_content_type( $tmp ) ?: 'image/jpeg';
+			$ext  = array(
+				'image/jpeg' => '.jpg',
+				'image/png'  => '.png',
+				'image/gif'  => '.gif',
+				'image/webp' => '.webp',
+			)[ $mime ] ?? '.jpg';
+			$name = ( $name !== '' ? $name : 'strava-photo' ) . $ext;
+		}
+
+		$file_array = array( 'name' => $name, 'tmp_name' => $tmp );
+		$id         = media_handle_sideload( $file_array, 0 );
+		if ( is_wp_error( $id ) ) {
+			@unlink( $tmp );
+			return $id;
+		}
+
+		if ( $caption !== '' ) {
+			wp_update_post( array( 'ID' => $id, 'post_excerpt' => $caption ) );
+		}
+		update_post_meta( $id, '_wp_attachment_image_alt', $alt_text );
+		return (int) $id;
+	}
+
 }


### PR DESCRIPTION
## Summary

Three loosely related improvements to Strava Stories, batched together (would be happy to split if you'd rather):

- **Dashboard widget — SVG route map.** Decode `summary_polyline` and render the route as a lightweight SVG between the title and the stats. No external map dependency, cosine-corrected longitude so the shape doesn't squash at higher latitudes. Skips cleanly for activities with no GPS (treadmill, weights, pool swims).
- **Filter — re-allow trashed activities.** `drafted_activity_ids()` now excludes both `auto-draft` *and* `trash`, so trashing a draft releases the activity for re-drafting. Currently a trashed activity is silently filtered, which can be confusing — "I deleted it, why is it gone from the widget too?"
- **Drafts — photos.** `create_blog_draft` pulls activity photos via a new `get_activity_photos()` client method and sideloads each into the media library (capped at 12 to keep the click responsive). Single photo becomes a `wp:image`; multiple become a `wp:gallery`. URLs from Strava are CloudFront-signed and expire — sideloading keeps the post durable.
- **Drafts — outline tidy.**
  - The duplicate `<h2>` heading is dropped (`post_title` already exists).
  - Description moves above stats.
  - Stats become bare phrases instead of "Label: value":
    - `14.70 mi` (was `Distance: 14.70 mi`)
    - `2 hr 22 mins` — largest two non-zero units, drops seconds when an hour is present (`22 mins 4 secs`, `47 secs` for short ones)
    - `2259 ft elev gain`
    - Avg pace / avg speed dropped from drafts.

## Test plan

- [ ] Connect Strava on a fresh site; widget shows route map for outdoor activities, no map for indoor ones.
- [ ] Trash a generated draft → activity reappears in the widget carousel.
- [ ] Click "Let's blog it" on an activity with multiple photos → draft contains a `wp:gallery`.
- [ ] Click "Let's blog it" on an activity with one photo → draft contains a single `wp:image`.
- [ ] Click "Let's blog it" on an activity with no photos → draft has no image block, no error.
- [ ] Inspect a freshly-created draft: no H2, description above stats, stats are bare phrases as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
