### PR TITLE
Add option to hide an activity from the widget feed

### DIFF
--- a/assets/strava-stories.css
+++ b/assets/strava-stories.css
@@ -285,6 +285,43 @@
 	color: #787c82;
 }
 
+.strava-stories-widget__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.strava-stories-widget__hide {
+	color: #50575e;
+	text-decoration: none;
+}
+
+.strava-stories-widget__hide:hover:not([disabled]),
+.strava-stories-widget__hide:focus:not([disabled]) {
+	color: #1e1e1e;
+	text-decoration: underline;
+}
+
+.strava-stories-widget__notice {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	background: #f6f7f7;
+	border-left: 4px solid #2271b1;
+	border-radius: 3px;
+	font-size: 12px;
+	color: #1e1e1e;
+}
+
+.strava-stories-widget__notice-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 /* Admin page status pills */
 .strava-stories-status {
 	display: inline-block;

--- a/assets/strava-stories.css
+++ b/assets/strava-stories.css
@@ -285,41 +285,47 @@
 	color: #787c82;
 }
 
-.strava-stories-widget__actions {
-	display: flex;
+.strava-stories-widget__card {
+	position: relative;
+}
+
+.strava-stories-widget__dismiss {
+	position: absolute;
+	top: 6px;
+	right: 0;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: #787c82;
+	cursor: pointer;
+	border-radius: 2px;
+	display: inline-flex;
 	align-items: center;
-	gap: 8px;
+	justify-content: center;
+	transition: color 120ms ease, background-color 120ms ease;
 }
 
-.strava-stories-widget__hide {
-	color: #50575e;
-	text-decoration: none;
-}
-
-.strava-stories-widget__hide:hover:not([disabled]),
-.strava-stories-widget__hide:focus:not([disabled]) {
+.strava-stories-widget__dismiss:hover,
+.strava-stories-widget__dismiss:focus-visible {
 	color: #1e1e1e;
-	text-decoration: underline;
+	background: #f0f0f1;
 }
 
-.strava-stories-widget__notice {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 8px;
-	padding: 8px 12px;
-	background: #f6f7f7;
-	border-left: 4px solid #2271b1;
-	border-radius: 3px;
-	font-size: 12px;
-	color: #1e1e1e;
+.strava-stories-widget__dismiss:focus-visible {
+	outline: 2px solid #2271b1;
+	outline-offset: 0;
 }
 
-.strava-stories-widget__notice-text {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+.strava-stories-widget__dismiss .dashicons {
+	font-size: 16px;
+	width: 16px;
+	height: 16px;
+}
+
+.strava-stories-widget__card-header {
+	padding-right: 28px;
 }
 
 /* Admin page status pills */

--- a/assets/strava-stories.js
+++ b/assets/strava-stories.js
@@ -38,13 +38,6 @@
 	const next       = root.querySelector( '.strava-stories-widget__nav--next' );
 	const pager      = root.querySelector( '.strava-stories-widget__pager' );
 	const blog       = root.querySelector( '.strava-stories-widget__blog' );
-	const hide       = root.querySelector( '.strava-stories-widget__hide' );
-	const notice     = root.querySelector( '.strava-stories-widget__notice' );
-	const noticeText = root.querySelector( '.strava-stories-widget__notice-text' );
-	const undo       = root.querySelector( '.strava-stories-widget__undo' );
-
-	let undoTimer = null;
-	let undoState = null;
 
 	let activities = [];
 	let index      = 0;
@@ -195,6 +188,14 @@
 		const card = document.createElement( 'article' );
 		card.className = 'strava-stories-widget__card';
 
+		const dismiss = document.createElement( 'button' );
+		dismiss.type = 'button';
+		dismiss.className = 'strava-stories-widget__dismiss';
+		dismiss.setAttribute( 'aria-label', __( 'Hide this activity' ) );
+		dismiss.innerHTML = '<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>';
+		dismiss.addEventListener( 'click', function () { hideActivity( activity ); } );
+		card.appendChild( dismiss );
+
 		const header = document.createElement( 'header' );
 		header.className = 'strava-stories-widget__card-header';
 		const title = document.createElement( 'h4' );
@@ -258,14 +259,12 @@
 			prev.disabled = true;
 			next.disabled = true;
 			blog.disabled = true;
-			hide.disabled = true;
 			pager.textContent = '';
 			return;
 		}
 		prev.disabled = index <= 0;
 		next.disabled = index >= activities.length - 1;
 		blog.disabled = false;
-		hide.disabled = false;
 		pager.textContent = sprintf( __( '%1$d of %2$d' ), index + 1, activities.length );
 	}
 
@@ -301,27 +300,11 @@
 	prev.addEventListener( 'click', function () { show( index - 1 ); } );
 	next.addEventListener( 'click', function () { show( index + 1 ); } );
 
-	function clearNotice() {
-		if ( undoTimer ) { window.clearTimeout( undoTimer ); undoTimer = null; }
-		undoState = null;
-		notice.hidden = true;
-		noticeText.textContent = '';
-	}
+	function hideActivity( activity ) {
+		const at = activities.indexOf( activity );
+		if ( at < 0 ) { return; }
 
-	function showNotice( message ) {
-		noticeText.textContent = message;
-		notice.hidden = false;
-		if ( undoTimer ) { window.clearTimeout( undoTimer ); }
-		undoTimer = window.setTimeout( clearNotice, 8000 );
-	}
-
-	hide.addEventListener( 'click', function () {
-		if ( ! activities.length ) { return; }
-		const removed   = activities[ index ];
-		const removedAt = index;
-
-		// Optimistic update — drop locally so the list shrinks immediately.
-		activities.splice( index, 1 );
+		activities.splice( at, 1 );
 		if ( index >= activities.length ) {
 			index = Math.max( 0, activities.length - 1 );
 		}
@@ -332,29 +315,11 @@
 			updateChrome();
 		}
 
-		undoState = { activity: removed, at: removedAt };
-		showNotice( sprintf( __( 'Hidden “%1$s”.' ), removed.name || removed.sport_label ) );
-
-		request( 'POST', 'ignore', { activity_id: removed.id } ).catch( function () {
+		request( 'POST', 'ignore', { activity_id: activity.id } ).catch( function () {
 			// If the server didn't accept it, the next reload will bring the
 			// activity back — no need to disrupt the current view.
 		} );
-	} );
-
-	undo.addEventListener( 'click', function () {
-		if ( ! undoState ) { return; }
-		const restored = undoState;
-		clearNotice();
-		request( 'DELETE', 'ignore', { activity_id: restored.activity.id } ).then( function () {
-			const at = Math.min( restored.at, activities.length );
-			activities.splice( at, 0, restored.activity );
-			index = at;
-			if ( stage.dataset.state === 'empty' ) { stage.innerHTML = ''; }
-			show( index );
-		} ).catch( function () {
-			showError( __( 'Could not restore activity.' ) );
-		} );
-	} );
+	}
 
 	root.addEventListener( 'keydown', function ( ev ) {
 		if ( ev.target.tagName === 'IFRAME' || ev.target.tagName === 'INPUT' ) { return; }

--- a/assets/strava-stories.js
+++ b/assets/strava-stories.js
@@ -33,11 +33,18 @@
 		return;
 	}
 
-	const stage  = root.querySelector( '.strava-stories-widget__stage' );
-	const prev   = root.querySelector( '.strava-stories-widget__nav--prev' );
-	const next   = root.querySelector( '.strava-stories-widget__nav--next' );
-	const pager  = root.querySelector( '.strava-stories-widget__pager' );
-	const blog   = root.querySelector( '.strava-stories-widget__blog' );
+	const stage      = root.querySelector( '.strava-stories-widget__stage' );
+	const prev       = root.querySelector( '.strava-stories-widget__nav--prev' );
+	const next       = root.querySelector( '.strava-stories-widget__nav--next' );
+	const pager      = root.querySelector( '.strava-stories-widget__pager' );
+	const blog       = root.querySelector( '.strava-stories-widget__blog' );
+	const hide       = root.querySelector( '.strava-stories-widget__hide' );
+	const notice     = root.querySelector( '.strava-stories-widget__notice' );
+	const noticeText = root.querySelector( '.strava-stories-widget__notice-text' );
+	const undo       = root.querySelector( '.strava-stories-widget__undo' );
+
+	let undoTimer = null;
+	let undoState = null;
 
 	let activities = [];
 	let index      = 0;
@@ -251,12 +258,14 @@
 			prev.disabled = true;
 			next.disabled = true;
 			blog.disabled = true;
+			hide.disabled = true;
 			pager.textContent = '';
 			return;
 		}
 		prev.disabled = index <= 0;
 		next.disabled = index >= activities.length - 1;
 		blog.disabled = false;
+		hide.disabled = false;
 		pager.textContent = sprintf( __( '%1$d of %2$d' ), index + 1, activities.length );
 	}
 
@@ -291,6 +300,61 @@
 
 	prev.addEventListener( 'click', function () { show( index - 1 ); } );
 	next.addEventListener( 'click', function () { show( index + 1 ); } );
+
+	function clearNotice() {
+		if ( undoTimer ) { window.clearTimeout( undoTimer ); undoTimer = null; }
+		undoState = null;
+		notice.hidden = true;
+		noticeText.textContent = '';
+	}
+
+	function showNotice( message ) {
+		noticeText.textContent = message;
+		notice.hidden = false;
+		if ( undoTimer ) { window.clearTimeout( undoTimer ); }
+		undoTimer = window.setTimeout( clearNotice, 8000 );
+	}
+
+	hide.addEventListener( 'click', function () {
+		if ( ! activities.length ) { return; }
+		const removed   = activities[ index ];
+		const removedAt = index;
+
+		// Optimistic update — drop locally so the list shrinks immediately.
+		activities.splice( index, 1 );
+		if ( index >= activities.length ) {
+			index = Math.max( 0, activities.length - 1 );
+		}
+		if ( activities.length ) {
+			show( index );
+		} else {
+			showEmpty();
+			updateChrome();
+		}
+
+		undoState = { activity: removed, at: removedAt };
+		showNotice( sprintf( __( 'Hidden “%1$s”.' ), removed.name || removed.sport_label ) );
+
+		request( 'POST', 'ignore', { activity_id: removed.id } ).catch( function () {
+			// If the server didn't accept it, the next reload will bring the
+			// activity back — no need to disrupt the current view.
+		} );
+	} );
+
+	undo.addEventListener( 'click', function () {
+		if ( ! undoState ) { return; }
+		const restored = undoState;
+		clearNotice();
+		request( 'DELETE', 'ignore', { activity_id: restored.activity.id } ).then( function () {
+			const at = Math.min( restored.at, activities.length );
+			activities.splice( at, 0, restored.activity );
+			index = at;
+			if ( stage.dataset.state === 'empty' ) { stage.innerHTML = ''; }
+			show( index );
+		} ).catch( function () {
+			showError( __( 'Could not restore activity.' ) );
+		} );
+	} );
 
 	root.addEventListener( 'keydown', function ( ev ) {
 		if ( ev.target.tagName === 'IFRAME' || ev.target.tagName === 'INPUT' ) { return; }

--- a/includes/class-strava-stories-rest.php
+++ b/includes/class-strava-stories-rest.php
@@ -37,32 +37,16 @@ class Strava_Stories_Rest {
 			self::NAMESPACE,
 			'/ignore',
 			array(
-				array(
-					'methods'             => 'POST',
-					'callback'            => array( __CLASS__, 'ignore_activity' ),
-					'permission_callback' => array( __CLASS__, 'can_use' ),
-					'args'                => array(
-						'activity_id' => array(
-							'required'          => true,
-							'sanitize_callback' => static function ( $value ) {
-								$s = is_scalar( $value ) ? (string) $value : '';
-								return ctype_digit( $s ) ? $s : '';
-							},
-						),
-					),
-				),
-				array(
-					'methods'             => 'DELETE',
-					'callback'            => array( __CLASS__, 'unignore_activity' ),
-					'permission_callback' => array( __CLASS__, 'can_use' ),
-					'args'                => array(
-						'activity_id' => array(
-							'required'          => true,
-							'sanitize_callback' => static function ( $value ) {
-								$s = is_scalar( $value ) ? (string) $value : '';
-								return ctype_digit( $s ) ? $s : '';
-							},
-						),
+				'methods'             => 'POST',
+				'callback'            => array( __CLASS__, 'ignore_activity' ),
+				'permission_callback' => array( __CLASS__, 'can_use' ),
+				'args'                => array(
+					'activity_id' => array(
+						'required'          => true,
+						'sanitize_callback' => static function ( $value ) {
+							$s = is_scalar( $value ) ? (string) $value : '';
+							return ctype_digit( $s ) ? $s : '';
+						},
 					),
 				),
 			)
@@ -323,22 +307,6 @@ class Strava_Stories_Rest {
 		$ids     = self::ignored_activity_ids( $user_id );
 		$ids[ $activity_id ] = true;
 		update_user_meta( $user_id, self::IGNORED_META_KEY, array_keys( $ids ) );
-		return new WP_REST_Response( array( 'ok' => true ), 200 );
-	}
-
-	public static function unignore_activity( WP_REST_Request $request ): WP_REST_Response {
-		$activity_id = (string) $request->get_param( 'activity_id' );
-		if ( $activity_id === '' || ! ctype_digit( $activity_id ) ) {
-			return new WP_REST_Response( array( 'ok' => false, 'error' => 'invalid_activity' ), 400 );
-		}
-		$user_id = get_current_user_id();
-		$ids     = self::ignored_activity_ids( $user_id );
-		unset( $ids[ $activity_id ] );
-		if ( empty( $ids ) ) {
-			delete_user_meta( $user_id, self::IGNORED_META_KEY );
-		} else {
-			update_user_meta( $user_id, self::IGNORED_META_KEY, array_keys( $ids ) );
-		}
 		return new WP_REST_Response( array( 'ok' => true ), 200 );
 	}
 

--- a/includes/class-strava-stories-rest.php
+++ b/includes/class-strava-stories-rest.php
@@ -17,6 +17,8 @@ class Strava_Stories_Rest {
 
 	public const NAMESPACE = 'strava-stories/v1';
 
+	private const IGNORED_META_KEY = '_strava_stories_ignored';
+
 	public static function boot(): void {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_routes' ) );
 	}
@@ -29,6 +31,40 @@ class Strava_Stories_Rest {
 				'methods'             => 'GET',
 				'callback'            => array( __CLASS__, 'list_activities' ),
 				'permission_callback' => array( __CLASS__, 'can_use' ),
+			)
+		);
+		register_rest_route(
+			self::NAMESPACE,
+			'/ignore',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( __CLASS__, 'ignore_activity' ),
+					'permission_callback' => array( __CLASS__, 'can_use' ),
+					'args'                => array(
+						'activity_id' => array(
+							'required'          => true,
+							'sanitize_callback' => static function ( $value ) {
+								$s = is_scalar( $value ) ? (string) $value : '';
+								return ctype_digit( $s ) ? $s : '';
+							},
+						),
+					),
+				),
+				array(
+					'methods'             => 'DELETE',
+					'callback'            => array( __CLASS__, 'unignore_activity' ),
+					'permission_callback' => array( __CLASS__, 'can_use' ),
+					'args'                => array(
+						'activity_id' => array(
+							'required'          => true,
+							'sanitize_callback' => static function ( $value ) {
+								$s = is_scalar( $value ) ? (string) $value : '';
+								return ctype_digit( $s ) ? $s : '';
+							},
+						),
+					),
+				),
 			)
 		);
 		register_rest_route(
@@ -76,13 +112,15 @@ class Strava_Stories_Rest {
 		}
 
 		$drafted = self::drafted_activity_ids();
-		if ( ! empty( $drafted ) ) {
+		$ignored = self::ignored_activity_ids( $user_id );
+		$excluded = $drafted + $ignored;
+		if ( ! empty( $excluded ) ) {
 			$activities = array_values(
 				array_filter(
 					$activities,
-					static function ( $a ) use ( $drafted ) {
+					static function ( $a ) use ( $excluded ) {
 						$id = isset( $a['id'] ) && is_scalar( $a['id'] ) ? (string) $a['id'] : '';
-						return $id === '' || ! isset( $drafted[ $id ] );
+						return $id === '' || ! isset( $excluded[ $id ] );
 					}
 				)
 			);
@@ -274,6 +312,49 @@ class Strava_Stories_Rest {
 			'at'                => (int) ( $a['at'] ?? 0 ),
 			'stats'             => $stats,
 		);
+	}
+
+	public static function ignore_activity( WP_REST_Request $request ): WP_REST_Response {
+		$activity_id = (string) $request->get_param( 'activity_id' );
+		if ( $activity_id === '' || ! ctype_digit( $activity_id ) ) {
+			return new WP_REST_Response( array( 'ok' => false, 'error' => 'invalid_activity' ), 400 );
+		}
+		$user_id = get_current_user_id();
+		$ids     = self::ignored_activity_ids( $user_id );
+		$ids[ $activity_id ] = true;
+		update_user_meta( $user_id, self::IGNORED_META_KEY, array_keys( $ids ) );
+		return new WP_REST_Response( array( 'ok' => true ), 200 );
+	}
+
+	public static function unignore_activity( WP_REST_Request $request ): WP_REST_Response {
+		$activity_id = (string) $request->get_param( 'activity_id' );
+		if ( $activity_id === '' || ! ctype_digit( $activity_id ) ) {
+			return new WP_REST_Response( array( 'ok' => false, 'error' => 'invalid_activity' ), 400 );
+		}
+		$user_id = get_current_user_id();
+		$ids     = self::ignored_activity_ids( $user_id );
+		unset( $ids[ $activity_id ] );
+		if ( empty( $ids ) ) {
+			delete_user_meta( $user_id, self::IGNORED_META_KEY );
+		} else {
+			update_user_meta( $user_id, self::IGNORED_META_KEY, array_keys( $ids ) );
+		}
+		return new WP_REST_Response( array( 'ok' => true ), 200 );
+	}
+
+	/**
+	 * @return array<string, true>
+	 */
+	private static function ignored_activity_ids( int $user_id ): array {
+		$raw = get_user_meta( $user_id, self::IGNORED_META_KEY, true );
+		$ids = array();
+		foreach ( (array) $raw as $value ) {
+			$id = is_scalar( $value ) ? (string) $value : '';
+			if ( $id !== '' && ctype_digit( $id ) ) {
+				$ids[ $id ] = true;
+			}
+		}
+		return $ids;
 	}
 
 	/**

--- a/includes/class-strava-stories-widget.php
+++ b/includes/class-strava-stories-widget.php
@@ -87,21 +87,10 @@ class Strava_Stories_Widget {
 
 				<footer class="strava-stories-widget__footer">
 					<span class="strava-stories-widget__pager" aria-live="polite"></span>
-					<div class="strava-stories-widget__actions">
-						<button type="button" class="button button-link strava-stories-widget__hide" disabled>
-							<?php esc_html_e( 'Hide', 'strava-stories' ); ?>
-						</button>
-						<button type="button" class="button button-primary strava-stories-widget__blog" disabled>
-							<?php esc_html_e( 'Create draft', 'strava-stories' ); ?>
-						</button>
-					</div>
-				</footer>
-				<div class="strava-stories-widget__notice" role="status" aria-live="polite" hidden>
-					<span class="strava-stories-widget__notice-text"></span>
-					<button type="button" class="button-link strava-stories-widget__undo">
-						<?php esc_html_e( 'Undo', 'strava-stories' ); ?>
+					<button type="button" class="button button-primary strava-stories-widget__blog" disabled>
+						<?php esc_html_e( 'Create draft', 'strava-stories' ); ?>
 					</button>
-				</div>
+				</footer>
 			<?php endif; ?>
 		</div>
 		<?php

--- a/includes/class-strava-stories-widget.php
+++ b/includes/class-strava-stories-widget.php
@@ -87,10 +87,21 @@ class Strava_Stories_Widget {
 
 				<footer class="strava-stories-widget__footer">
 					<span class="strava-stories-widget__pager" aria-live="polite"></span>
-					<button type="button" class="button button-primary strava-stories-widget__blog" disabled>
-						<?php esc_html_e( 'Create draft', 'strava-stories' ); ?>
-					</button>
+					<div class="strava-stories-widget__actions">
+						<button type="button" class="button button-link strava-stories-widget__hide" disabled>
+							<?php esc_html_e( 'Hide', 'strava-stories' ); ?>
+						</button>
+						<button type="button" class="button button-primary strava-stories-widget__blog" disabled>
+							<?php esc_html_e( 'Create draft', 'strava-stories' ); ?>
+						</button>
+					</div>
 				</footer>
+				<div class="strava-stories-widget__notice" role="status" aria-live="polite" hidden>
+					<span class="strava-stories-widget__notice-text"></span>
+					<button type="button" class="button-link strava-stories-widget__undo">
+						<?php esc_html_e( 'Undo', 'strava-stories' ); ?>
+					</button>
+				</div>
 			<?php endif; ?>
 		</div>
 		<?php

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,3 +9,4 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 delete_option( 'strava_stories_oauth_app' );
 delete_metadata( 'user', 0, 'strava_stories_token', '', true );
+delete_metadata( 'user', 0, '_strava_stories_ignored', '', true );


### PR DESCRIPTION
## Summary
- Adds a **Hide** button to the dashboard widget so an activity can be excluded from the feed without creating a draft.
- Stores per-user hidden IDs in `_strava_stories_ignored` user meta; `/activities` filters both drafted and ignored IDs.
- New REST routes: `POST /strava-stories/v1/ignore` and `DELETE /strava-stories/v1/ignore` (powering an in-widget Undo notice).
- Cleans up the user meta on plugin uninstall.

Closes #10.

## Test plan
- [ ] Connect Strava and load the dashboard widget.
- [ ] Click **Hide** on an activity — it disappears from the feed and an undo notice appears.
- [ ] Click **Undo** — the activity returns to its previous slot.
- [ ] Reload the dashboard — hidden activities stay hidden.
- [ ] Hide all visible activities — the empty state renders.
- [ ] Uninstall the plugin (test env) — `_strava_stories_ignored` meta is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)