### PR TITLE
Add hover tooltip to dismiss × on activity cards

### DIFF
--- a/assets/strava-stories.js
+++ b/assets/strava-stories.js
@@ -192,6 +192,7 @@
 		dismiss.type = 'button';
 		dismiss.className = 'strava-stories-widget__dismiss';
 		dismiss.setAttribute( 'aria-label', __( 'Hide this activity' ) );
+		dismiss.title = __( 'Hide this activity' );
 		dismiss.innerHTML = '<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>';
 		dismiss.addEventListener( 'click', function () { hideActivity( activity ); } );
 		card.appendChild( dismiss );


### PR DESCRIPTION
## Summary
- Sets `dismiss.title = "Hide this activity"` on the activity-card dismiss button so hovering surfaces the action (matching the Habit Creator widget's pattern).
- Mirrors the existing `aria-label` so the same hint is now available to sighted mouse users.

Closes #13

## Test plan
- [ ] Load the Strava Stories widget on the dashboard
- [ ] Hover the × button on a card and confirm "Hide this activity" appears
- [ ] Click × and confirm dismiss still works as before